### PR TITLE
Adding a setting that allows to remember the config in local storage (or not)

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,6 @@
 var clockConfig = {
     host: 'ws://localhost:13900/',
     node: 'default',
-    seconds: 150
+    seconds: 150,
+    rememberSettings: false
 }

--- a/js/ClockControlsCtrl.js
+++ b/js/ClockControlsCtrl.js
@@ -13,6 +13,7 @@ angular.module('Clock',['ngStorage'])
         '$scope','$timeout','$opener','$localStorage',
         function($scope,$timeout,$opener,$localStorage) {
 
+            //load settings from storage, which has been populated by now by the main controller
             $scope.config = $localStorage.config;
 
             var actions = ['arm','start','stop','mode','pause'];

--- a/js/ClockCtrl.js
+++ b/js/ClockCtrl.js
@@ -73,6 +73,9 @@ angular.module('Clock',['ngStorage'])
             $scope.$storage = $localStorage.$default({
                 config: urlConfig || clockConfig
             });
+            if (clockConfig && !clockConfig.rememberSettings) {
+                $scope.$storage.config = clockConfig;
+            }
             var handlers = {};
             $scope.bgColor = 'black';
             $scope.state = 'stopped';

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,16 @@ The port can be changed in localserver.js
 
 **Note:** currently the control panel (when pressing 'c') does not send commands. I.e. the clock in combination with mhub only listens. Using the controls will only affect the local instance of the clock (no other browser windows or running clocks).
 
+Configuration
+-----
+
+There is a configuration file that allows you to configure the clock. It has the following fields:
+
+- `host`: the Mhub host (see 'Usage with Mhub')
+- `node`: the Mhub node (see 'Usage with Mhub')
+- `seconds`: the number of seconds to count down from
+- `rememberSettings`: whether to remember adjusted settings. By default, this is set to `false`. This way, when you refresh the clock, it jumps back to the defaults. If you run this clock locally, you may set this to `true`, that way, any changes in the control window are remembered.
+
 Clock Mhub protocol
 -----
 


### PR DESCRIPTION
This defaults to false, to allow the online version to keep always working, but can be set to true locally to not have to update the config every time