### PR TITLE
Fix typo

### DIFF
--- a/js/ClockCtrl.js
+++ b/js/ClockCtrl.js
@@ -156,7 +156,7 @@ angular.module('Clock',['ngStorage'])
                 if ($scope.ws) {
                     $scope.ws.close();
                 }
-                $scope.conect();
+                $scope.connect();
                 $scope.armTime = config.seconds * 1;
                 //save to the url
                 console.log(config);


### PR DESCRIPTION
Fix a typo that prevents saving of settings to url. In the config window. The "update config" button should save the config to a url